### PR TITLE
add --keep argument to allow test resources to be kept

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,19 @@ getOptions() - get options for making requests to AWS
 
 ## Running with `jest`
 
-- `yarn jest '--profile=default' '--stack=my-service-dev' --runInBand`
+### Arguments
+- When running tests with `jest` using `sls-test-tools` matchers there are certain parameters needed for `sls-test-tools` to make assertions.
+- These are passed as command line arguments, using quotation to match `jests` convention on test arguments.
+
+**Required**
+  - `'--stack=my-service-dev'` - the CloudFormation stack name of the stack under test.
+
+**Optional**
+  - `'--profile=[PROFILE NAME]'` (will default to `default`)
+  - `'--region=[AWS Region]'` (will default to `eu-west-2`)
+  - `'--keep=true'` - keeps testing resources up to avoid creation throttles (e.g. SQS Queue created for EventBridge assertions)
+
+- To avoid issues we recommend `--runInBand`
 
 ```
 import { AWSClient, EventBridge } from "sls-test-tools";

--- a/src/helpers/eventBridge.js
+++ b/src/helpers/eventBridge.js
@@ -4,7 +4,12 @@ export default class EventBridge {
   async init(eventBridgeName) {
     this.eventBridgeClient = new AWSClient.EventBridge();
     this.eventBridgeName = eventBridgeName;
+    const keepArg = process.argv.filter((x) => x.startsWith("--keep="))[0];
+    this.keep = keepArg ? keepArg.split("=")[1] : false;
     this.sqsClient = new AWSClient.SQS();
+    if (!this.keep) {
+      console.info("If running repeatedly add '--keep=true' to keep testing resources up to avoid creation throttles")
+    }
     const queueName = `${eventBridgeName}-testing-queue`;
     const queueResult = await this.sqsClient
       .createQueue({
@@ -87,6 +92,8 @@ export default class EventBridge {
       })
       .promise();
 
+    await this.getEvents(); // need to clear this manual published event from the SQS observer queue.
+
     return result;
   }
 
@@ -99,6 +106,19 @@ export default class EventBridge {
 
     const result = await this.sqsClient.receiveMessage(queueParams).promise();
 
+    const messageHandlers = result.Messages.map(
+      message => ({
+        Id: message.MessageId,
+        ReceiptHandle: message.ReceiptHandle,
+      })
+    )
+    if (messageHandlers.length > 0) {
+      await this.sqsClient.deleteMessageBatch({
+        Entries : messageHandlers,
+        QueueUrl: this.QueueUrl,
+      }).promise();
+    }
+
     return result;
   }
 
@@ -108,17 +128,20 @@ export default class EventBridge {
         QueueUrl: this.QueueUrl,
       })
       .promise();
-
     return result;
   }
 
   async destroy() {
-    const result = await this.sqsClient
-      .deleteQueue({
-        QueueUrl: this.QueueUrl,
-      })
-      .promise();
+    if(!this.keep) {
+      await this.sqsClient
+        .deleteQueue({
+          QueueUrl: this.QueueUrl,
+        })
+        .promise();
+    } else {
+      await this.clear();
+    }
 
-    return result;
+    return true;
   }
 }


### PR DESCRIPTION
- Added `--keep=true` argument to enable testing resources (like SQS queue for EventBridge) to be kept.
- This was triggered by throttling of queue creation after deletion on repeated runs.
  - In the future this can also be used to speed up test runs.

- Note, also removed bugs in messages being left on the SQS queue when events added to EventBridge via manual publish via `sls-test-tools`.