### PR TITLE
Add first S3 assertion toHaveS3ObjectWithNameEqualTo(bucketName, objectName)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ sls-test-tools is currently being actively maintained, yet is in alpha. Your fee
 ## Assertions:
 
 ### EventBridge
-An interface to the deployed EventBridge, allowing events to be injected and intercepted via an SQS queue and EventBridge rule.
-
 ```
     expect(eventBridgeEvents).toHaveEvent();
 
     expect(eventBridgeEvents).toHaveEventWithSource("order.created");
+```
+
+### S3
+```
+    await expect("BUCKET NAME").toHaveS3ObjectWithNameEqualTo("FILE NAME");
+    // note this is an async assertion and requires "await"
 ```
 
 ## Helpers
@@ -54,6 +58,7 @@ getOptions() - get options for making requests to AWS
 ```
 
 ### EventBridge
+An interface to the deployed EventBridge, allowing events to be injected and intercepted via an SQS queue and EventBridge rule.
 
 #### Static
 

--- a/src/assertions/toHaveObjectWithNameEqualTo/index.js
+++ b/src/assertions/toHaveObjectWithNameEqualTo/index.js
@@ -1,0 +1,33 @@
+import { AWSClient } from '../../helpers/general';
+
+export default {
+  async toHaveS3ObjectWithNameEqualTo(bucketName, objectName) {
+    const s3 = new AWSClient.S3();
+    const params = {
+      Bucket: bucketName,
+      Key: objectName,
+    };
+
+    let testResult;
+    try {
+      await s3.getObject(params).promise();
+      testResult = {
+        message: () =>
+          `expected ${bucketName} to have object with name ${objectName}`,
+        pass: true,
+      };
+    } catch (error) {
+      if (error.code === 'NoSuchKey') {
+        testResult = {
+          message: () =>
+            `expected ${bucketName} to have object with name ${objectName} - not found`,
+          pass: false,
+        };
+      } else {
+        throw error;
+      }
+    }
+
+    return testResult;
+  },
+};


### PR DESCRIPTION
- Adding first assertion on S3
- toHaveS3ObjectWithNameEqualTo(bucketName, objectName)
- Also shows the first `async` assertions, enabling cleaner abstraction for assertions.