### PR TITLE
Fixed eventBridge.getEvents() when there are no available messages in SQS queue

### DIFF
--- a/src/helpers/eventBridge.js
+++ b/src/helpers/eventBridge.js
@@ -108,7 +108,7 @@ export default class EventBridge {
 
     const result = await this.sqsClient.receiveMessage(queueParams).promise();
 
-    const messageHandlers = result.Messages.map((message) => ({
+    const messageHandlers = result.Messages?.map((message) => ({
       Id: message.MessageId,
       ReceiptHandle: message.ReceiptHandle,
     }));


### PR DESCRIPTION
Hey! 

First of all, I want to thank you for this library! I found it useful and helpful keep it up 🚀 

Well, I received the following error `TypeError: Cannot read property 'map' of undefined` when trying to call `eventBridge.getEvents()` on an empty SQS queue.

The problem is that `Messages` attribute is not returned when calling `sqs.receiveMessage`, only `ResponseMetadata` attribute is returned in this particular case.

