### PR TITLE
Delete EventBridge rule and target on SQS queue destroy

### DIFF
--- a/src/helpers/eventBridge.js
+++ b/src/helpers/eventBridge.js
@@ -27,24 +27,25 @@ export default class EventBridge {
       account: [`${accountId}`],
     };
 
-    const ruleName = `test-${eventBridgeName}-rule`;
+    this.ruleName = `test-${eventBridgeName}-rule`;
     await this.eventBridgeClient
       .putRule({
-        Name: ruleName,
+        Name: this.ruleName,
         EventBusName: eventBridgeName,
         EventPattern: JSON.stringify(pattern),
         State: "ENABLED",
       })
       .promise();
 
+    this.targetId = "1";
     await this.eventBridgeClient
       .putTargets({
         EventBusName: eventBridgeName,
-        Rule: ruleName,
+        Rule: this.ruleName,
         Targets: [
           {
             Arn: sqsArn,
-            Id: "1",
+            Id: this.targetId,
           },
         ],
       })
@@ -140,6 +141,15 @@ export default class EventBridge {
           QueueUrl: this.QueueUrl,
         })
         .promise();
+      await this.eventBridgeClient.removeTargets({
+        EventBusName: this.eventBridgeName,
+        Rule: this.ruleName,
+        Ids: [this.targetId],
+      }).promise();
+      await this.eventBridgeClient.deleteRule({
+        Name: this.ruleName,
+        EventBusName: this.eventBridgeName,
+      }).promise();
     } else {
       await this.clear();
     }


### PR DESCRIPTION
Hi @BenEllerby @hamilton-s,

I've been using your lib for serverless integration testing, and to do so I deploy a new serverless stack at each Pull Requests, run my tests and then destroy the stack. The problem is that my remove command fails because I cannot delete an EventBridge instance if it still has rules.

So I thought it would be nice if this lib would also clean the target and rule of the EventBridge instance at the same time it cleans the SQS queue.

What do you think ?