### PR TITLE
feat: create toExistInDynamoTable assertion

### DIFF
--- a/src/assertions/toExistInDynamoTable/index.js
+++ b/src/assertions/toExistInDynamoTable/index.js
@@ -1,0 +1,47 @@
+import { AWSClient } from "../../helpers/general";
+
+export default {
+  async toExistInDynamoTable({ PK, SK }, tableName) {
+    const docClient = new AWSClient.DynamoDB.DocumentClient();
+
+    if (!docClient) {
+      return {
+        message: () => "expected table to contain document client",
+        pass: false,
+      };
+    }
+
+    if (!SK) {
+      const queryParams = {
+        TableName: tableName,
+        KeyConditionExpression: "#pk = :pk",
+        ExpressionAttributeNames: {
+          "#pk": "PK",
+        },
+        ExpressionAttributeValues: {
+          ":pk": PK,
+        },
+        Limit: 1,
+      };
+
+      const result = await docClient.query(queryParams).promise();
+      return {
+        message: () => `expected to find ${PK} in ${tableName}`,
+        pass: result.Count === 1,
+      };
+    }
+
+    const getParams = {
+      TableName: tableName,
+      Key: {
+        PK,
+        SK,
+      },
+    };
+    const result = await docClient.get(getParams).promise();
+    return {
+      message: () => `expected to find ${PK} in ${tableName}`,
+      pass: result.Item !== undefined,
+    };
+  },
+};


### PR DESCRIPTION
Hello!
I'm working on integration tests on my Serverless project and I was missing custom Jest expects to check for Item presence in DynamoDB.
If you have ideas for Dynamo checks and no spare time I would be glad to help :) 